### PR TITLE
Add neo-codap scripts to top-level package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ node_js: node
 install:
 - travis_retry gem install s3_website -v 3.4.0
 - travis_retry pip install awscli --upgrade --user
-- travis_retry yarn
+- travis_retry yarn install --frozen-lockfile
+- travis_retry cd neo-codap && yarn install --frozen-lockfile && cd ..
 before_script: npm run build
 script: ./s3_deploy.sh
 cache:
@@ -12,3 +13,4 @@ cache:
   yarn: true
   directories:
     - node_modules
+    - neo-codap/node_modules

--- a/neo-codap/package.json
+++ b/neo-codap/package.json
@@ -18,7 +18,8 @@
     "start": "react-scripts-ts start",
     "build": "react-scripts-ts build",
     "test": "react-scripts-ts test --env=jsdom",
-    "test:coverage": "react-scripts-ts test --env=jsdom --coverage --verbose",
+    "test:ci": "CI=true npm run test",
+    "test:coverage": "npm run test -- --coverage --verbose",
     "eject": "react-scripts-ts eject"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Concord Consortium Workspaces",
   "scripts": {
-    "build": "npm-run-all --parallel copy-root cs:build",
+    "build": "npm-run-all --parallel cs:build nc:build",
 
     "copy-root": "copyfiles -f root/**/*.* dist/",
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,11 @@
     "cs:start": "npm-run-all --parallel cs:build:watch cs:browse",
     "cs:start:secure": "npm-run-all --parallel cs:build:watch cs:browse",
     "cs:dev:start": "npm-run-all --parallel cs:dev:build:watch cs:browse",
-    "cs:dev:start:secure": "npm-run-all --parallel cs:dev:build:watch cs:browse:secure"
+    "cs:dev:start:secure": "npm-run-all --parallel cs:dev:build:watch cs:browse:secure",
+    "nc:build": "cd neo-codap && npm run build",
+    "nc:start": "cd neo-codap && npm run start",
+    "nc:test": "cd neo-codap && npm run test:ci",
+    "test": "npm-run-all --parallel nc:test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- `nc:build` runs neo-codap's `build` script
- `nc:start` runs neo-codap's `start` script
- `nc:test` runs neo-codap's (new) `test:ci` script which runs the tests in continuous integration mode rather than interactive watch mode
- `test` runs `nc:test` and eventually may run other tests as well